### PR TITLE
Replace codecov markdown code

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ title: AddressBook Level-3
 ---
 
 [![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
-[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![codecov](https://codecov.io/gh/AY2122S1-CS2103-F09-4/tp/branch/master/graph/badge.svg?token=GXI6LDV6WE)](https://codecov.io/gh/AY2122S1-CS2103-F09-4/tp)
 
 ![Ui](images/Ui.png)
 


### PR DESCRIPTION
Replace default markdown code with team's codecov markdown code to reflect coverage of this project.